### PR TITLE
add stress helper

### DIFF
--- a/StressHelper/README.md
+++ b/StressHelper/README.md
@@ -1,0 +1,22 @@
+## StressHelper
+
+`StressHelper` is a [Byteman's User-Defined Rule Helper](https://downloads.jboss.org/byteman/4.0.17/byteman-programmers-guide.html#user-defined-rule-helpers), which used to inject CPU or memory stress into JVM.
+
+| Type | Method | Description |
+| ---- | ------ | ------------|
+| void | injectCPUStress(String name, int cpuCount) | Inject CPU stress into the JVM. The `name` must be unique in one Java process, the `cpuCount` is the number of CPU which `StressHelper` used. |
+| void | injectMemStress(String name, String memType) | Inject Memory stress into the JVM until out of memory. The `name` must be unique in one Java process, the `memType` is the memory type, it's value can be "heap" and "stack". |
+
+### Example
+
+```txt
+RULE cpu test
+CLASS org.chaos_mesh.chaos_agent.TriggerThread
+METHOD triggerFunc
+HELPER org.chaos_mesh.byteman.helper.StressHelper
+AT ENTRY
+IF true
+DO
+    injectCPUStress("cpu test", 2);
+ENDRULE
+```

--- a/StressHelper/pom.xml
+++ b/StressHelper/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.chaos_mesh.byteman.helper</groupId>
+  <artifactId>StressHelper</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0</version>
+  <name>StressHelper</name>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman</artifactId>
+      <version>4.0.9</version>
+    </dependency>
+  </dependencies>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
+    <java.version>11</java.version>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+</project>

--- a/StressHelper/src/main/java/org/chaos_mesh/byteman/helper/StressHelper.java
+++ b/StressHelper/src/main/java/org/chaos_mesh/byteman/helper/StressHelper.java
@@ -1,3 +1,15 @@
+// Copyright 2022 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package org.chaos_mesh.byteman.helper;
 
 import java.util.*;

--- a/StressHelper/src/main/java/org/chaos_mesh/byteman/helper/StressHelper.java
+++ b/StressHelper/src/main/java/org/chaos_mesh/byteman/helper/StressHelper.java
@@ -1,0 +1,244 @@
+package org.chaos_mesh.byteman.helper;
+
+import java.util.*;
+
+import org.jboss.byteman.rule.Rule;
+import org.jboss.byteman.rule.helper.Helper;
+import org.jboss.byteman.rule.Action;
+
+import java.nio.ByteBuffer;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+public class StressHelper extends Helper
+{
+    static HashMap<String, Stress> stresses = new HashMap<String, Stress>();
+
+    protected StressHelper(Rule rule) {
+        super(rule);
+    }
+
+    public static void uninstalled(Rule rule)
+    {
+        Stress stress = stresses.get(rule.getName());
+        stress.quit();
+        stresses.remove(rule.getName());
+    }
+
+    public void injectCPUStress(String name, int cpuCount)
+    {
+        Stress stress = stresses.get(name);
+        if (stress != null)
+        {
+            return;
+        }
+
+        stress = new CPUStress(name, cpuCount);
+        stresses.put(name, stress);
+        stress.load();
+    }
+
+    public void injectMemStress(String name, String memType)
+    {
+        Stress stress = stresses.get(name);
+        if (stress != null)
+        {
+            return;
+        }
+
+        stress = new MemoryStress(name, memType);
+        stresses.put(name, stress);
+        stress.load();
+    }
+}
+
+/*
+    Stress is an interface used for inject stress on Java process, include Memory and CPU.
+ */
+interface Stress {
+    // load the stress
+    public void load();
+
+    // quit stops the stress load
+    public void quit();
+}
+
+class CPUStress implements Stress {
+    private String name;
+    private int cpuCount;
+    private ArrayList<CPUStressThread> threads;
+
+    CPUStress(String name, int cpuCount) {
+        this.name = name;
+        this.cpuCount = cpuCount;
+        threads = new ArrayList<CPUStressThread>();
+    }
+
+    public void load() {
+        for (int i = 0; i < cpuCount; i++) {
+            CPUStressThread thread = new CPUStressThread(name + i);
+            threads.add(thread);
+            thread.start();
+        }
+    }
+
+    public void quit() {
+        for (int i = 0; i < threads.size(); i++) {
+            threads.get(i).shutdown();
+        }
+    }
+}
+
+class MemoryStress implements Stress {
+    private String name;
+    private String type;
+    private MemoryStressThread thread;
+
+    MemoryStress(String name, String type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public void load() {
+        thread = new MemoryStressThread(name, type);
+        thread.start();
+    }
+
+    public void quit() {
+        thread.shutdown();
+    }
+}
+
+interface StressRunnable extends Runnable {
+
+    public void shutdown();
+}
+
+class CPUStressThread implements StressRunnable {
+    private Thread t;
+    private String threadName;
+    private boolean flag;
+   
+    private ReentrantLock lock = new ReentrantLock();
+    
+    CPUStressThread( String name ) {
+        threadName = name;
+        flag = true;
+        Helper.verbose("Creating thread " +  threadName );
+    }
+   
+    public void run() {
+        Helper.verbose("Running thread " +  threadName );
+        
+        while (true) {
+            lock.lock();
+            boolean exit = !flag; 
+            lock.unlock();
+            if (exit) {
+                break;
+            }
+        }
+
+        Helper.verbose("Exiting thread " +  threadName );
+    }
+   
+    public void start() {
+        Helper.verbose("Starting thread " +  threadName );
+    
+        if (t == null) {
+            t = new Thread (this, threadName);
+            t.start ();
+        }
+   }
+
+    public void shutdown() {
+        Helper.verbose("Shutdown thread " +  threadName );
+        lock.lock();
+        flag = false;
+        lock.unlock();
+    }
+}
+
+class MemoryStressThread implements StressRunnable {
+    private Thread t;
+    private String threadName;
+    private boolean flag;
+    private String type;
+
+    private ReentrantLock lock = new ReentrantLock();
+
+    MemoryStressThread(String name, String type) {
+        threadName = name;
+        this.type = type;
+        flag = true;
+        Helper.verbose("Creating thread " +  threadName + ", type " + type);
+    }
+
+    public void run() {
+        Helper.verbose("Running thread " +  threadName );
+        ArrayList<String> increaseSizeData = new ArrayList<String>();
+        boolean oom = false;
+
+        while (true) {
+            lock.lock();
+            boolean exit = !flag;
+            lock.unlock();
+            if (exit) {
+                increaseSizeData = null;
+                ThreadTask.setStop(true);
+                System.gc(); 
+                break;
+            }
+
+            if (oom) {
+                try {
+                    Thread.sleep(500);
+                } catch (Exception e) {
+                    Helper.verbose("exception: " + e);
+                }
+            } else {
+                if (this.type.equals("heap")) {
+                    try {
+                        increaseSizeData.add("123456");
+                    } catch (OutOfMemoryError e) {
+                        oom = true;
+                        Helper.verbose("exception: " + e);
+                    }
+                } else if (this.type.equals("stack")) {
+                    try {
+                        ThreadTask task = new ThreadTask();
+                        task.setInterval(9999999);
+                        Thread th = new Thread(task);
+                        th.start();
+                    } catch (OutOfMemoryError e) {
+                        oom = true;
+                        Helper.verbose("exception: " + e);
+                    }
+
+                }
+            }
+        }
+
+        Helper.verbose("Exiting thread " +  threadName );
+    }
+   
+    public void start () {
+        Helper.verbose("Starting thread " +  threadName );
+    
+        if (t == null) {
+            t = new Thread (this, threadName);
+            t.start ();
+        }
+   }
+
+    public void shutdown() {
+        Helper.verbose("Shutdown thread " +  threadName );
+        lock.lock();
+        flag = false;
+        lock.unlock();
+    }
+}

--- a/StressHelper/src/main/java/org/chaos_mesh/byteman/helper/ThreadTask.java
+++ b/StressHelper/src/main/java/org/chaos_mesh/byteman/helper/ThreadTask.java
@@ -1,0 +1,50 @@
+package org.chaos_mesh.byteman.helper;
+
+import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class ThreadTask implements Runnable{
+    public static boolean stop = false;
+    private static ReentrantLock lock = new ReentrantLock();
+
+    int interval;
+    public ThreadTask() {
+        
+    }
+
+    public static void setStop(boolean stop) {
+        ThreadTask.lock.lock();
+        ThreadTask.stop = stop;
+        ThreadTask.lock.unlock();
+    }
+
+    public static boolean getStop() {
+        ThreadTask.lock.lock();
+        stop = ThreadTask.stop;
+        ThreadTask.lock.unlock();
+
+        return stop;
+    }
+
+    public void setInterval(int interval) {
+        this.interval = interval;
+    }
+    
+    public void run() {
+        System.out.println("chaos thread: " + Thread.currentThread().getName());
+        
+        if (interval > 0) {
+            for (int i = 0; i < interval; i++) {
+                try {
+                    Thread.sleep(1000);
+                    if (this.getStop()) {
+                        System.out.println("exit the chaos thread");
+                        return;
+                    }
+                } catch(Exception e) {
+                    System.out.println("get exception when execute new chaos thread:" + e);
+                }         
+            }
+        }
+    }
+}

--- a/StressHelper/src/main/java/org/chaos_mesh/byteman/helper/ThreadTask.java
+++ b/StressHelper/src/main/java/org/chaos_mesh/byteman/helper/ThreadTask.java
@@ -1,6 +1,18 @@
+// Copyright 2022 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.chaos_mesh.byteman.helper;
 
-import java.util.*;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class ThreadTask implements Runnable{

--- a/StressHelper/src/test/java/org/chaos_mesh/byteman/helper/AppTest.java
+++ b/StressHelper/src/test/java/org/chaos_mesh/byteman/helper/AppTest.java
@@ -1,0 +1,39 @@
+package org.chaos_mesh.byteman.helper;
+
+import java.util.HashMap;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+    }
+}

--- a/StressHelper/src/test/java/org/chaos_mesh/byteman/helper/AppTest.java
+++ b/StressHelper/src/test/java/org/chaos_mesh/byteman/helper/AppTest.java
@@ -1,3 +1,16 @@
+// Copyright 2022 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.chaos_mesh.byteman.helper;
 
 import java.util.HashMap;


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

## StressHelper

`StressHelper` is a [Byteman's User-Defined Rule Helper](https://downloads.jboss.org/byteman/4.0.17/byteman-programmers-guide.html#user-defined-rule-helpers), which used to inject CPU or memory stress into JVM.

| Type | Method | Description |
| ---- | ------ | ------------|
| void | injectCPUStress(String name, int cpuCount) | Inject CPU stress into the JVM. The `name` must be unique in one Java process, the `cpuCount` is the number of CPU which `StressHelper` used. |
| void | injectMemStress(String name, String memType) | Inject Memory stress into the JVM until out of memory. The `name` must be unique in one Java process, the `memType` is the memory type, it's value can be "heap" and "stack". |

### Example

```txt
RULE cpu test
CLASS org.chaos_mesh.chaos_agent.TriggerThread
METHOD triggerFunc
HELPER org.chaos_mesh.byteman.helper.StressHelper
AT ENTRY
IF true
DO
    injectCPUStress("cpu test", 2);
ENDRULE
```