### PR TITLE
support gc helper

### DIFF
--- a/GCHelper/README.md
+++ b/GCHelper/README.md
@@ -1,0 +1,17 @@
+## GCHelper
+
+`StressHelper` is a [Byteman's User-Defined Rule Helper](https://downloads.jboss.org/byteman/4.0.17/byteman-programmers-guide.html#user-defined-rule-helpers), which used to trigger garbage collection in JVM.
+
+### Example
+
+```txt
+RULE gc test
+CLASS org.chaos_mesh.chaos_agent.TriggerThread
+METHOD triggerFunc
+HELPER org.chaos_mesh.byteman.helper.GCHelper
+AT ENTRY
+IF true
+DO
+    gc();
+ENDRULE
+```

--- a/GCHelper/README.md
+++ b/GCHelper/README.md
@@ -1,6 +1,6 @@
 ## GCHelper
 
-`StressHelper` is a [Byteman's User-Defined Rule Helper](https://downloads.jboss.org/byteman/4.0.17/byteman-programmers-guide.html#user-defined-rule-helpers), which used to trigger garbage collection in JVM.
+`GCHelper` is a [Byteman's User-Defined Rule Helper](https://downloads.jboss.org/byteman/4.0.17/byteman-programmers-guide.html#user-defined-rule-helpers), which used to trigger garbage collection in JVM.
 
 ### Example
 

--- a/GCHelper/pom.xml
+++ b/GCHelper/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.chaos_mesh.byteman.helper</groupId>
+  <artifactId>GCHelper</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0</version>
+  <name>GCHelper</name>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman</artifactId>
+      <version>4.0.9</version>
+    </dependency>
+  </dependencies>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
+    <java.version>11</java.version>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+</project>

--- a/GCHelper/src/main/java/org/chaos_mesh/byteman/helper/GCHelper.java
+++ b/GCHelper/src/main/java/org/chaos_mesh/byteman/helper/GCHelper.java
@@ -1,0 +1,46 @@
+// Copyright 2022 Chaos Mesh Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.chaos_mesh.byteman.helper;
+
+import java.util.*;
+
+import org.jboss.byteman.rule.Rule;
+import org.jboss.byteman.rule.helper.Helper;
+import org.jboss.byteman.rule.Action;
+
+import java.nio.ByteBuffer;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+public class GCHelper extends Helper
+{
+    protected GCHelper(Rule rule) {
+        super(rule);
+    }
+
+    public static void installed(Rule rule)
+    {
+        System.out.println("byteman gc helper trigger gc");
+        System.gc();
+    }
+
+    public void gc()
+    {
+        // do nothing
+        return;
+    }
+}

--- a/GCHelper/src/test/java/org/chaos_mesh/byteman/helper/AppTest.java
+++ b/GCHelper/src/test/java/org/chaos_mesh/byteman/helper/AppTest.java
@@ -1,0 +1,38 @@
+package org.chaos_mesh.byteman.helper;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}


### PR DESCRIPTION
Signed-off-by: xiang <xiang13225080@163.com>

## GCHelper

`GCHelper` is a [Byteman's User-Defined Rule Helper](https://downloads.jboss.org/byteman/4.0.17/byteman-programmers-guide.html#user-defined-rule-helpers), which used to trigger garbage collection in JVM.

### Example

```txt
RULE gc test
CLASS org.chaos_mesh.chaos_agent.TriggerThread
METHOD triggerFunc
HELPER org.chaos_mesh.byteman.helper.GCHelper
AT ENTRY
IF true
DO
    gc();
ENDRULE
```